### PR TITLE
Player sprite hot updates

### DIFF
--- a/src/features/render/lib/phaser/scenes/WorldScene.tsx
+++ b/src/features/render/lib/phaser/scenes/WorldScene.tsx
@@ -195,7 +195,7 @@ export class WorldScene extends WarpableScene {
     };
   }
 
-  preload() {}
+  preload() { }
 
   create() {
     this.camera = this.cameras.main;
@@ -406,23 +406,20 @@ export class WorldScene extends WarpableScene {
     profiles: Array<ProfileInfo>,
   ) {
     Object.keys(entityUpdates).forEach((entityId) => {
-      const entityUpdate = entityUpdates[entityId];
 
+      const entityUpdate = entityUpdates[entityId];
       if (entityUpdate.Type === "Avatar") {
         const spriteKeyBase = this.spriteKeyBase(entityId, entityUpdate);
-
         if (entityId === this.playerAddress) {
           // Update the player's sprite key if the skin has changed
           if (spriteKeyBase !== this.playerSpriteKeyBase) {
             this.playerSpriteKeyBase = spriteKeyBase;
-
             // Update the player's animation with the new skin
             const playerSprite = this.player.getAt(0) as Phaser.GameObjects.Sprite;
             playerSprite.play(`${this.playerSpriteKeyBase}_idle`);
           }
           return; // Skip further movement logic for the player
         }
-
         if (this.avatarEntityContainers[entityId]) {
           console.log(`Updating entity ${entityId}`);
           const entityContainer = this.avatarEntityContainers[entityId];
@@ -442,21 +439,20 @@ export class WorldScene extends WarpableScene {
                 entityContainer.destroy();
               },
             });
-            return; // Return early if the entity is being hidden
           }
 
-          const entitySprite = entityContainer.getAt(0) as Phaser.GameObjects.Sprite;
+          const entitySprite = entityContainer.getAt(
+            0,
+          ) as Phaser.GameObjects.Sprite;
 
           const updatePosition: Point2D = {
             x: entityUpdate.Position[0] * this.tileSizeScaled[0],
             y: entityUpdate.Position[1] * this.tileSizeScaled[1],
           };
 
+
           // Check previous position if it exists
-          const previousPosition = entityContainer.lastPosition || {
-            x: entityContainer.x,
-            y: entityContainer.y,
-          };
+          const previousPosition = entityContainer.lastPosition || { x: entityContainer.x, y: entityContainer.y };
 
           // Determine if the entity is moving left or right and flip the sprite accordingly
           if (updatePosition.x < previousPosition.x) {
@@ -468,10 +464,7 @@ export class WorldScene extends WarpableScene {
           }
 
           // Save the current position as the last position for the next update
-          entityContainer.lastPosition = {
-            x: updatePosition.x,
-            y: updatePosition.y,
-          };
+          entityContainer.lastPosition = { x: updatePosition.x, y: updatePosition.y };
 
           if (
             !this.withinBox(entityContainer, {
@@ -492,7 +485,7 @@ export class WorldScene extends WarpableScene {
             this.physics.moveToObject(
               entityContainer,
               this.entityTargets[entityId],
-              120
+              120,
             );
             this.physics.add.overlap(
               entityContainer,
@@ -503,21 +496,22 @@ export class WorldScene extends WarpableScene {
                   entityContainer.body as Phaser.Physics.Arcade.Body;
                 containerBody.setVelocity(0, 0);
                 entitySprite.play(`${spriteKeyBase}_idle`);
+                // entitySprite.setPosition(updatePosition.x, updatePosition.y);
 
                 this.entityTargets[entityId]?.destroy();
                 delete this.entityTargets[entityId];
-              }
+              },
             );
           }
         } else {
           console.log(`Creating entity ${entityId}`);
           const profileMaybe = profiles?.find(
-            (profile) => profile.ProfileId === entityUpdate.Metadata?.ProfileId
+            (profile) => profile.ProfileId === entityUpdate.Metadata?.ProfileId,
           );
           const entityContainer = this.createAvatarEntityContainer(
             entityId,
             entityUpdate,
-            profileMaybe
+            profileMaybe,
           );
           this.avatarEntityContainers[entityId] = entityContainer;
         }
@@ -532,7 +526,10 @@ export class WorldScene extends WarpableScene {
           console.log(`Skipping hidden warp ${entityId}`);
           return;
         }
-        this.warpSprites[entityId] = this.createWarpEntity(entityId, entityUpdate);
+        this.warpSprites[entityId] = this.createWarpEntity(
+          entityId,
+          entityUpdate,
+        );
       }
     });
   }

--- a/src/features/render/lib/phaser/scenes/WorldScene.tsx
+++ b/src/features/render/lib/phaser/scenes/WorldScene.tsx
@@ -195,7 +195,7 @@ export class WorldScene extends WarpableScene {
     };
   }
 
-  preload() { }
+  preload() {}
 
   create() {
     this.camera = this.cameras.main;
@@ -465,7 +465,7 @@ export class WorldScene extends WarpableScene {
 
           // Save the current position as the last position for the next update
           entityContainer.lastPosition = { x: updatePosition.x, y: updatePosition.y };
-
+          
           if (
             !this.withinBox(entityContainer, {
               center: updatePosition,


### PR DESCRIPTION
This allows for changes to players sprites to appear to the player in real time.
Previously only a reload would update your own sprite.
The bug for warps breaking your skin to PlayerSpriteTxId still exists, but this overwrites it after an update 